### PR TITLE
remove any dependency on TMC26XStepper in platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -62,7 +62,6 @@ platform          = atmelavr
 board             = megaatmega2560
 board_build.f_cpu = 16000000L
 lib_deps          = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
 src_filter        = ${common.default_src_filter} +<src/HAL/AVR>
 
 #
@@ -73,7 +72,6 @@ platform          = atmelavr
 board             = megaatmega1280
 board_build.f_cpu = 16000000L
 lib_deps          = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
 src_filter        = ${common.default_src_filter} +<src/HAL/AVR>
 
 #
@@ -84,7 +82,6 @@ platform          = atmelavr
 board             = reprap_rambo
 board_build.f_cpu = 16000000L
 lib_deps          = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
 src_filter        = ${common.default_src_filter} +<src/HAL/AVR>
 
 #
@@ -95,7 +92,6 @@ platform          = atmelavr
 board             = fysetc_f6_13
 board_build.f_cpu = 16000000L
 lib_deps          = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
 src_filter        = ${common.default_src_filter} +<src/HAL/AVR>
 
 #
@@ -106,7 +102,6 @@ platform          = atmelavr
 board             = fysetc_f6_14
 board_build.f_cpu = 16000000L
 lib_deps          = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
 src_filter        = ${common.default_src_filter} +<src/HAL/AVR>
 
 #
@@ -116,7 +111,6 @@ src_filter        = ${common.default_src_filter} +<src/HAL/AVR>
 platform      = atmelavr
 board         = sanguino_atmega644p
 lib_deps      = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
 src_filter    = ${common.default_src_filter} +<src/HAL/AVR>
 
 #
@@ -126,7 +120,6 @@ src_filter    = ${common.default_src_filter} +<src/HAL/AVR>
 platform      = atmelavr
 board         = sanguino_atmega1284p
 lib_deps      = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
 src_filter    = ${common.default_src_filter} +<src/HAL/AVR>
 
 #
@@ -136,7 +129,6 @@ src_filter    = ${common.default_src_filter} +<src/HAL/AVR>
 platform      = atmelavr
 board         = sanguino_atmega1284p
 lib_deps      = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
 src_filter    = ${common.default_src_filter} +<src/HAL/AVR>
 lib_ignore    = TMCStepper
 upload_speed  = 57600
@@ -148,7 +140,6 @@ upload_speed  = 57600
 platform      = atmelavr
 board         = sanguino_atmega1284p
 lib_deps      = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
 src_filter    = ${common.default_src_filter} +<src/HAL/AVR>
 lib_ignore    = TMCStepper
 upload_speed  = 115200
@@ -164,7 +155,6 @@ upload_speed  = 115200
 platform      = teensy
 board         = at90usb1286
 lib_deps      = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
 lib_ignore    = TMCStepper
 src_filter    = ${common.default_src_filter} +<src/HAL/AVR>
 
@@ -733,7 +723,6 @@ src_filter        = ${common.default_src_filter} +<src/HAL/STM32>
 platform      = teensy
 board         = teensy31
 lib_deps      = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
 lib_ignore    = Adafruit NeoPixel
 src_filter    = ${common.default_src_filter} +<src/HAL/TEENSY31_32>
 
@@ -744,7 +733,6 @@ src_filter    = ${common.default_src_filter} +<src/HAL/TEENSY31_32>
 platform      = teensy
 board         = teensy35
 lib_deps      = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
 lib_ignore    = Adafruit NeoPixel
 src_filter    = ${common.default_src_filter} +<src/HAL/TEENSY35_36>
 
@@ -849,5 +837,4 @@ platform    = atmelavr
 board       = megaatmega2560
 build_flags = -c -H -std=gnu++11 -Wall -Os -D__MARLIN_FIRMWARE__
 lib_deps    = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
 src_filter  = +<src/Marlin.cpp>


### PR DESCRIPTION
### Description

Remove any mention of TMC26XStepper from platfromio.ini

### Benefits

the dependency on TMC26XStepper (https://github.com/trinamic/TMC26XStepper/archive/master.zip) currently returns 404 so PlatformIO builds fail and as mentioned in #27 this library isn't in use. By removing this platformio builds no longer fail